### PR TITLE
Added collapsible headings to TOC sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 dist
+node_modules

--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -34,6 +34,8 @@ function createToC(headings: NodeListOf<Element>) {
   toc.appendChild(scrollWrapper)
   scrollWrapper.appendChild(ul)
 
+  const MAX_HEADING_LEVEL = 6;
+
   // Track heading hierarchy
   interface HeadingNode {
     element: HTMLLIElement;
@@ -150,7 +152,7 @@ function createToC(headings: NodeListOf<Element>) {
     // Update the last parent at this level
     lastParentAtLevel.set(level, node)
     // Clear all deeper levels
-    for (let clearLevel = level + 1; clearLevel <= 6; clearLevel++) {
+    for (let clearLevel = level + 1; clearLevel <= MAX_HEADING_LEVEL; clearLevel++) {
       lastParentAtLevel.delete(clearLevel)
     }
   }

--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -44,7 +44,11 @@ function createToC(headings: NodeListOf<Element>) {
     childrenWrapper: HTMLDivElement | null;
     isCollapsed: boolean;
     icon: HTMLSpanElement;
+    href: string;
   }
+
+  // Map to track heading nodes by their href for auto-expansion
+  const nodesByHref = new Map<string, HeadingNode>();
 
   const getHeadingLevel = (tagName: string): number => {
     return parseInt(tagName.charAt(1)); // h1 -> 1, h2 -> 2, etc.
@@ -94,7 +98,8 @@ function createToC(headings: NodeListOf<Element>) {
       children: null,
       childrenWrapper: null,
       isCollapsed: false,
-      icon: icon
+      icon: icon,
+      href: href
     }
 
     // Add click handler for collapse icon
@@ -118,6 +123,9 @@ function createToC(headings: NodeListOf<Element>) {
     
     const level = getHeadingLevel(h.tagName.toLowerCase())
     const { li, node, icon } = createLi((h.textContent || '').trim(), href, h.tagName.toLowerCase(), level)
+    
+    // Store node by href for later lookup
+    nodesByHref.set(href, node);
     
     // Find parent (closest heading with lower level)
     let parent: HeadingNode | null = null
@@ -157,11 +165,15 @@ function createToC(headings: NodeListOf<Element>) {
     }
   }
   
+  // Store nodesByHref on toc element for access in scroll handler
+  (toc as any).__nodesByHref = nodesByHref;
+  
   return toc
 }
 
 function activeTocLinkOnScroll(toc: HTMLDivElement, headings: NodeListOf<Element>) {
     const activeClass = 'active';
+    const nodesByHref = (toc as any).__nodesByHref as Map<string, any>;
 
     function getLinkByHeading(heading: Element) {
       const href = getHeadingHref(heading);
@@ -177,9 +189,40 @@ function activeTocLinkOnScroll(toc: HTMLDivElement, headings: NodeListOf<Element
       return rect.top
     }
 
+    function expandParents(href: string) {
+      const node = nodesByHref.get(href);
+      if (!node) return;
+      
+      // Find all parent nodes and expand them
+      let currentElement = node.element.parentElement;
+      while (currentElement) {
+        // Check if this is a collapsed children wrapper
+        if (currentElement.classList.contains('toc-children') && currentElement.classList.contains('collapsed')) {
+          // Find the parent node that owns this wrapper
+          const parentLi = currentElement.parentElement as HTMLLIElement;
+          if (parentLi) {
+            for (const [, parentNode] of nodesByHref) {
+              if (parentNode.element === parentLi && parentNode.childrenWrapper === currentElement) {
+                // Expand this parent
+                parentNode.isCollapsed = false;
+                parentNode.childrenWrapper.classList.remove('collapsed');
+                parentNode.icon.classList.remove('collapsed');
+                break;
+              }
+            }
+          }
+        }
+        currentElement = currentElement.parentElement;
+      }
+    }
+
     function activate(heading: Element, lastActiveHeading?: Element) {
       if (lastActiveHeading) {
         getLinkByHeading(lastActiveHeading)?.parentElement!.classList.remove(activeClass);
+      }
+      const href = getHeadingHref(heading);
+      if (href) {
+        expandParents(href);
       }
       getLinkByHeading(heading)?.parentElement!.classList.add(activeClass);
     }

--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -34,18 +34,78 @@ function createToC(headings: NodeListOf<Element>) {
   toc.appendChild(scrollWrapper)
   scrollWrapper.appendChild(ul)
 
-  const createLi = (text: string, href: string, headingTag: string) => {
+  // Track heading hierarchy
+  interface HeadingNode {
+    element: HTMLLIElement;
+    level: number;
+    children: HTMLUListElement | null;
+    childrenWrapper: HTMLDivElement | null;
+    isCollapsed: boolean;
+  }
+  const headingNodes: HeadingNode[] = [];
+
+  const getHeadingLevel = (tagName: string): number => {
+    return parseInt(tagName.charAt(1)); // h1 -> 1, h2 -> 2, etc.
+  }
+
+  const createCollapseIcon = (hasChildren: boolean): HTMLSpanElement => {
+    const icon = document.createElement('span')
+    icon.classList.add('collapse-icon')
+    if (hasChildren) {
+      icon.innerHTML = '▸' // chevron that will rotate
+      icon.classList.add('has-children')
+    }
+    return icon
+  }
+
+  const toggleCollapse = (node: HeadingNode, icon: HTMLSpanElement) => {
+    if (!node.childrenWrapper) return
+    
+    node.isCollapsed = !node.isCollapsed
+    if (node.isCollapsed) {
+      node.childrenWrapper.classList.add('collapsed')
+      icon.classList.add('collapsed')
+    } else {
+      node.childrenWrapper.classList.remove('collapsed')
+      icon.classList.remove('collapsed')
+    }
+  }
+
+  const createLi = (text: string, href: string, headingTag: string, level: number) => {
     debugLog('createLi', text, href, headingTag)
     const li = document.createElement('li')
-      const a = document.createElement('a')
-      a.setAttribute('href', href)
-        const label = document.createElement('div')
-        label.classList.add(`toc-label-${headingTag}`)
-        label.innerText = text
-        a.appendChild(label)
-      li.appendChild(a)
-    ul.appendChild(li)
+    const a = document.createElement('a')
+    a.setAttribute('href', href)
+    
+    const icon = createCollapseIcon(false)
+    const label = document.createElement('div')
+    label.classList.add(`toc-label-${headingTag}`)
+    label.innerText = text
+    
+    a.appendChild(icon)
+    a.appendChild(label)
+    li.appendChild(a)
+
+    const node: HeadingNode = {
+      element: li,
+      level: level,
+      children: null,
+      childrenWrapper: null,
+      isCollapsed: false
+    }
+    headingNodes.push(node)
+
+    // Add click handler for collapse icon
+    icon.addEventListener('click', (e) => {
+      e.preventDefault()
+      e.stopPropagation()
+      toggleCollapse(node, icon)
+    })
+
+    return { li, node, icon }
   }
+
+  let lastParentAtLevel: Map<number, HeadingNode> = new Map()
 
   for (const h of headings) {
     const href = getHeadingHref(h)
@@ -53,8 +113,51 @@ function createToC(headings: NodeListOf<Element>) {
     if (!href) {
       continue
     }
-    createLi((h.textContent || '').trim(), href, h.tagName.toLowerCase())
+    
+    const level = getHeadingLevel(h.tagName.toLowerCase())
+    const { li, node, icon } = createLi((h.textContent || '').trim(), href, h.tagName.toLowerCase(), level)
+    
+    // Find parent (closest heading with lower level)
+    let parent: HeadingNode | null = null
+    for (let parentLevel = level - 1; parentLevel >= 1; parentLevel--) {
+      if (lastParentAtLevel.has(parentLevel)) {
+        parent = lastParentAtLevel.get(parentLevel)!
+        break
+      }
+    }
+
+    if (parent) {
+      // This is a child of a parent heading
+      if (!parent.children) {
+        // Create children container for parent
+        parent.childrenWrapper = document.createElement('div')
+        parent.childrenWrapper.classList.add('toc-children')
+        
+        parent.children = document.createElement('ul')
+        parent.childrenWrapper.appendChild(parent.children)
+        parent.element.appendChild(parent.childrenWrapper)
+        
+        // Update parent's icon to show it has children
+        const parentIcon = parent.element.querySelector('.collapse-icon') as HTMLSpanElement
+        if (parentIcon) {
+          parentIcon.classList.add('has-children')
+          parentIcon.innerHTML = '▸'
+        }
+      }
+      parent.children.appendChild(li)
+    } else {
+      // This is a top-level heading
+      ul.appendChild(li)
+    }
+
+    // Update the last parent at this level
+    lastParentAtLevel.set(level, node)
+    // Clear all deeper levels
+    for (let clearLevel = level + 1; clearLevel <= 6; clearLevel++) {
+      lastParentAtLevel.delete(clearLevel)
+    }
   }
+  
   return toc
 }
 

--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -41,8 +41,8 @@ function createToC(headings: NodeListOf<Element>) {
     children: HTMLUListElement | null;
     childrenWrapper: HTMLDivElement | null;
     isCollapsed: boolean;
+    icon: HTMLSpanElement;
   }
-  const headingNodes: HeadingNode[] = [];
 
   const getHeadingLevel = (tagName: string): number => {
     return parseInt(tagName.charAt(1)); // h1 -> 1, h2 -> 2, etc.
@@ -91,9 +91,9 @@ function createToC(headings: NodeListOf<Element>) {
       level: level,
       children: null,
       childrenWrapper: null,
-      isCollapsed: false
+      isCollapsed: false,
+      icon: icon
     }
-    headingNodes.push(node)
 
     // Add click handler for collapse icon
     icon.addEventListener('click', (e) => {
@@ -138,11 +138,8 @@ function createToC(headings: NodeListOf<Element>) {
         parent.element.appendChild(parent.childrenWrapper)
         
         // Update parent's icon to show it has children
-        const parentIcon = parent.element.querySelector('.collapse-icon') as HTMLSpanElement
-        if (parentIcon) {
-          parentIcon.classList.add('has-children')
-          parentIcon.innerHTML = '▸'
-        }
+        parent.icon.classList.add('has-children')
+        parent.icon.innerHTML = '▸'
       }
       parent.children.appendChild(li)
     } else {

--- a/src/content_style.scss
+++ b/src/content_style.scss
@@ -20,7 +20,7 @@ $gradient-height: 48px;
       padding-top: 8px;
       // left padding is to reserve space for the active highlight, otherwise it will be covered by overflow
       padding-left: 8px;
-      max-height: calc(100vh - 130px);
+      max-height: calc(100vh - 10px);
       overflow-y: auto;
       position: relative;
     }
@@ -53,6 +53,8 @@ $gradient-height: 48px;
     li > a {
       padding: 6px 8px;
       display: flex;
+      align-items: center;
+      gap: 6px;
     }
     li:hover, li.active {
       background-color: rgba(177, 186, 196, 0.12);
@@ -70,20 +72,71 @@ $gradient-height: 48px;
       border-radius: 6px;
     }
   }
+
+  // Collapse icon styles
+  .collapse-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    font-size: 24px;
+    opacity: 0;
+    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.2s ease;
+    user-select: none;
+    transform: rotate(90deg);
+    
+    &.has-children {
+      opacity: 0.6;
+      cursor: pointer;
+      
+      &:hover {
+        opacity: 1;
+      }
+      
+      &.collapsed {
+        transform: rotate(0deg);
+      }
+    }
+  }
+
+  // Nested children styles (wrapper div)
+  .toc-children {
+    display: grid;
+    grid-template-rows: 1fr;
+    transition: grid-template-rows 0.3s cubic-bezier(0.4, 0, 0.2, 1), 
+                margin-top 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+                opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    margin-top: 4px;
+    opacity: 1;
+    
+    &.collapsed {
+      grid-template-rows: 0fr;
+      margin-top: 0;
+      opacity: 0;
+    }
+    
+    // This wrapper is needed for grid animation to work properly
+    > * {
+      overflow: hidden;
+      min-height: 0;
+    }
+    
+    // The actual UL inside the wrapper
+    ul {
+      list-style: none;
+      margin-bottom: 0;
+      padding-left: $indent-unit;
+      
+      li {
+        margin-left: 0;
+      }
+    }
+  }
+  
   .toc-label-h1 {
     font-weight: 600;
-  }
-  .toc-label-h2 {
-    padding-left: $indent-unit * 1;
-  }
-  .toc-label-h3 {
-    padding-left: $indent-unit * 2;
-  }
-  .toc-label-h4 {
-    padding-left: $indent-unit * 3;
-  }
-  .toc-label-h5 {
-    padding-left: $indent-unit * 4;
   }
 }
 

--- a/src/content_style.scss
+++ b/src/content_style.scss
@@ -44,9 +44,13 @@ $transition-easing-standard: cubic-bezier(0.4, 0, 0.2, 1);
       text-decoration: none;
     }
   }
-  ul {
+  // Only apply to top-level ul, not nested ones
+  > .toc-sidebar-content > .scroll-wrapper > ul {
     list-style: none;
     margin-bottom: $gradient-height;
+  }
+
+  ul {
     li {
       border-radius: 6px;
       cursor: pointer;
@@ -59,9 +63,16 @@ $transition-easing-standard: cubic-bezier(0.4, 0, 0.2, 1);
       align-items: center;
       gap: 6px;
     }
-    li:hover, li.active {
+    // Only show hover/active background on direct hover, not on parent items
+    li > a:hover {
       background-color: rgba(177, 186, 196, 0.12);
       box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px max(1px, 0.0625rem) inset;
+      border-radius: 6px;
+    }
+    li.active > a {
+      background-color: rgba(177, 186, 196, 0.12);
+      box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px max(1px, 0.0625rem) inset;
+      border-radius: 6px;
     }
 
     li.active::after {

--- a/src/content_style.scss
+++ b/src/content_style.scss
@@ -1,5 +1,8 @@
 $indent-unit: 16px;
 $gradient-height: 48px;
+$transition-duration-normal: 0.3s;
+$transition-duration-fast: 0.2s;
+$transition-easing-standard: cubic-bezier(0.4, 0, 0.2, 1);
 
 .toc-sidebar {
   padding: 16px 0;
@@ -83,7 +86,7 @@ $gradient-height: 48px;
     flex-shrink: 0;
     font-size: 24px;
     opacity: 0;
-    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.2s ease;
+    transition: transform $transition-duration-fast $transition-easing-standard, opacity $transition-duration-fast ease;
     user-select: none;
     transform: rotate(90deg);
     
@@ -105,9 +108,9 @@ $gradient-height: 48px;
   .toc-children {
     display: grid;
     grid-template-rows: 1fr;
-    transition: grid-template-rows 0.3s cubic-bezier(0.4, 0, 0.2, 1), 
-                margin-top 0.3s cubic-bezier(0.4, 0, 0.2, 1),
-                opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    transition: grid-template-rows $transition-duration-normal $transition-easing-standard, 
+                margin-top $transition-duration-normal $transition-easing-standard,
+                opacity $transition-duration-normal $transition-easing-standard;
     margin-top: 4px;
     opacity: 1;
     


### PR DESCRIPTION
## What's Changed
Added collapsible functionality to the TOC sidebar, allowing users to collapse/expand nested headings for better navigation of large README files.

## Features
- Parent headings now show a chevron icon (▸) that rotates when clicked
- Clicking the icon collapses/expands all child headings underneath
- Smooth animations for collapsing and expanding with proper easing
- Icons only appear for headings that have children
- The hierarchy automatically respects heading levels (h2 under h1, h3 under h2, etc.)

## Technical Details
- Implemented hierarchical heading structure using parent-child relationships
- Used CSS Grid animations for smooth height transitions in both directions
- Single icon character (▸) rotates via CSS transforms to avoid jitter
- Maintained existing styling and behavior for non-collapsible items

## Screenshots
<img width="1702" height="1029" alt="Screenshot 2025-12-08 at 10 24 38 PM" src="https://github.com/user-attachments/assets/c17a1033-916e-443f-bfa1-d0b6d1707703" />




Before: Static list of all headings
After: Collapsible sections with smooth animations

## Testing
Tested on:
- Large README files with multiple heading levels
- Nested headings (h1 > h2 > h3 > h4)
- Smooth collapse/expand animations
- Active section highlighting still works correctly